### PR TITLE
Fix crashing in dns udp relay and handle more then 1 query

### DIFF
--- a/src/usr.sbin/relayd/relay_udp.c
+++ b/src/usr.sbin/relayd/relay_udp.c
@@ -223,6 +223,8 @@ relay_udp_server(int fd, short sig, void *arg)
 	void *priv = NULL;
 	ssize_t len;
 
+	event_add(&rlay->rl_ev, NULL);
+
 	if (relay_sessions >= RELAY_MAX_SESSIONS ||
 	    rlay->rl_conf.flags & F_DISABLE)
 		return;
@@ -503,7 +505,7 @@ relay_dns_request(struct rsession *con)
 	}
 
 	event_again(&con->se_ev, con->se_out.s, EV_TIMEOUT|EV_READ,
-	    relay_udp_response, &con->se_tv_start, &env->sc_timeout, con);
+	    relay_udp_response, &con->se_tv_start, &rlay->rl_conf.timeout, con);
 
 	return (0);
 }


### PR DESCRIPTION
While testing relayd as a dns relay we encountered the issue that relayd immediately crashes at the first request. We traced this to an incorrect sc_timeout which we replaced with the sc_timeout used everywhere else.

After solving this issue we got a reply over UDP, but after the first reply the relayd would stop serving any other requests. Looking at the TCP handler we concluded the addition of an event_add in the UDP server. At a first glance everything seems to work now, though this code would require the additional review of someone with a bit more expertise concerning relayd and libevent.
